### PR TITLE
update marburg stadtparlament +1

### DIFF
--- a/pp_hessen.js
+++ b/pp_hessen.js
@@ -59,6 +59,7 @@ var pp_hessen = {
 		lines: [
 			"viele Piraten",
 			"<a href='http://www.piratenpartei-marburg.de/abgeordnete'>1 Pirat im Kreistag</a>",
+			"<a href='http://www.piratenpartei-marburg.de/abgeordnete'>1 Pirat im Stadtparlament</a>",
 			"<a href='http://www.piratenpartei-marburg.de/mitmachen'>Mitmachen im Kreisverband</a>",
 		]
 	},


### PR DESCRIPTION
der sitz im stadtparlament wird wieder von einem piraten besessen
